### PR TITLE
fix: Make changes to account for multiple USDC variants

### DIFF
--- a/src/components/input/TokenSelectField.tsx
+++ b/src/components/input/TokenSelectField.tsx
@@ -1,4 +1,5 @@
 import { useField } from 'formik'
+import { useMemo } from 'react'
 import { TokenId, getTokenById, getTokenOptionsByChainId } from 'src/config/tokens'
 import { TokenIcon } from 'src/images/tokens/TokenIcon'
 import { useNetwork } from 'wagmi'
@@ -22,7 +23,10 @@ export function TokenSelectField({ name, label, onChange }: Props) {
   const [field, , helpers] = useField<string>(name)
 
   const { chain } = useNetwork()
-  const tokenOptions = chain ? getTokenOptionsByChainId(chain?.id) : Object.values(TokenId)
+  const tokenOptions = useMemo(() => {
+    return chain ? getTokenOptionsByChainId(chain.id) : Object.values(TokenId);
+  }, [chain]);
+  
 
   const handleChange = (optionValue: string) => {
     helpers.setValue(optionValue || '')

--- a/src/components/input/TokenSelectField.tsx
+++ b/src/components/input/TokenSelectField.tsx
@@ -1,12 +1,11 @@
 import { useField } from 'formik'
-import { TokenId, getTokenById } from 'src/config/tokens'
+import { TokenId, getTokenById, getTokenOptionsByChainId } from 'src/config/tokens'
 import { TokenIcon } from 'src/images/tokens/TokenIcon'
+import { useNetwork } from 'wagmi'
 
 import { ChevronIcon } from '../Chevron'
 
 import { Select } from './Select'
-
-const tokenOptions = Object.values(TokenId)
 
 type Props = {
   name: string
@@ -21,6 +20,9 @@ const DEFAULT_VALUE = {
 
 export function TokenSelectField({ name, label, onChange }: Props) {
   const [field, , helpers] = useField<string>(name)
+
+  const { chain } = useNetwork()
+  const tokenOptions = chain ? getTokenOptionsByChainId(chain?.id) : Object.values(TokenId)
 
   const handleChange = (optionValue: string) => {
     helpers.setValue(optionValue || '')

--- a/src/config/tokens.ts
+++ b/src/config/tokens.ts
@@ -110,6 +110,10 @@ export const TokenAddresses: Record<ChainId, Partial<Record<TokenId, Address>>> 
   },
 })
 
+export function isUSDCToken(tokenId: string) {
+  return USDCTokenIds.includes(tokenId as TokenId)
+}
+
 export function isNativeToken(tokenId: string) {
   return Object.keys(Tokens).includes(tokenId)
 }

--- a/src/config/tokens.ts
+++ b/src/config/tokens.ts
@@ -32,7 +32,7 @@ export const StableTokenIds = [
   TokenId.axlUSDC,
 ]
 
-export const USDCTokenIds = [TokenId.USDC, TokenId.axlUSDC]
+export const USDCVariantIds = [TokenId.USDC, TokenId.axlUSDC]
 
 export const CELO: Token = Object.freeze({
   id: TokenId.CELO,
@@ -110,8 +110,8 @@ export const TokenAddresses: Record<ChainId, Partial<Record<TokenId, Address>>> 
   },
 })
 
-export function isUSDCToken(tokenId: string) {
-  return USDCTokenIds.includes(tokenId as TokenId)
+export function isUSDCVariant(tokenId: string) {
+  return USDCVariantIds.includes(tokenId as TokenId)
 }
 
 export function isNativeToken(tokenId: string) {

--- a/src/config/tokens.ts
+++ b/src/config/tokens.ts
@@ -21,9 +21,18 @@ export enum TokenId {
   cEUR = 'cEUR',
   cREAL = 'cREAL',
   USDC = 'USDC',
+  axlUSDC = 'axlUSDC',
 }
 
-export const StableTokenIds = [TokenId.cUSD, TokenId.cEUR, TokenId.cREAL, TokenId.USDC]
+export const StableTokenIds = [
+  TokenId.cUSD,
+  TokenId.cEUR,
+  TokenId.cREAL,
+  TokenId.USDC,
+  TokenId.axlUSDC,
+]
+
+export const USDCTokenIds = [TokenId.USDC, TokenId.axlUSDC]
 
 export const CELO: Token = Object.freeze({
   id: TokenId.CELO,
@@ -60,6 +69,13 @@ export const USDC: Token = Object.freeze({
   color: Color.usdcBlue,
   decimals: 18,
 })
+export const axlUSDC: Token = Object.freeze({
+  id: TokenId.axlUSDC,
+  symbol: TokenId.axlUSDC,
+  name: 'Axelar Wrapped USDC',
+  color: Color.usdcBlue,
+  decimals: 18,
+})
 
 export const Tokens: Record<TokenId, Token> = {
   CELO,
@@ -67,9 +83,10 @@ export const Tokens: Record<TokenId, Token> = {
   cEUR,
   cREAL,
   USDC,
+  axlUSDC,
 }
 
-export const TokenAddresses: Record<ChainId, Record<TokenId, Address>> = Object.freeze({
+export const TokenAddresses: Record<ChainId, Partial<Record<TokenId, Address>>> = Object.freeze({
   [ChainId.Alfajores]: {
     [TokenId.CELO]: '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
     [TokenId.cUSD]: '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
@@ -89,7 +106,7 @@ export const TokenAddresses: Record<ChainId, Record<TokenId, Address>> = Object.
     [TokenId.cUSD]: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
     [TokenId.cEUR]: '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
     [TokenId.cREAL]: '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787',
-    [TokenId.USDC]: '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
+    [TokenId.axlUSDC]: '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
   },
 })
 

--- a/src/config/tokens.ts
+++ b/src/config/tokens.ts
@@ -122,6 +122,10 @@ export function isStableToken(tokenId: string) {
   return StableTokenIds.includes(tokenId as TokenId)
 }
 
+export function getTokenOptionsByChainId(chainId: ChainId) {
+  return Object.keys(TokenAddresses[chainId]) as TokenId[]
+}
+
 export function getTokenById(id: string): Token | null {
   return Tokens[id as TokenId] || null
 }

--- a/src/features/accounts/fetchBalances.ts
+++ b/src/features/accounts/fetchBalances.ts
@@ -1,7 +1,7 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
 import { BigNumberish, Contract } from 'ethers'
 import { BALANCE_STALE_TIME } from 'src/config/consts'
-import { TokenId, getTokenAddress } from 'src/config/tokens'
+import { TokenId, getTokenAddress, getTokenOptionsByChainId } from 'src/config/tokens'
 import type { AppDispatch, AppState } from 'src/features/store/store'
 import { validateAddress } from 'src/utils/addresses'
 import { isStale } from 'src/utils/time'
@@ -34,7 +34,7 @@ export const fetchBalances = createAsyncThunk<
 async function _fetchBalances(address: string, chainId: number) {
   validateAddress(address, 'fetchBalances')
   const tokenBalances: Partial<Record<TokenId, string>> = {}
-  for (const tokenId of Object.values(TokenId)) {
+  for (const tokenId of getTokenOptionsByChainId(chainId)) {
     const tokenAddr = getTokenAddress(tokenId, chainId)
     const provider = getProvider(chainId)
     const tokenContract = new Contract(tokenAddr, erc20ABI, provider)

--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -7,7 +7,7 @@ import { IconButton } from 'src/components/buttons/IconButton'
 import { SolidButton } from 'src/components/buttons/SolidButton'
 import { RadioInput } from 'src/components/input/RadioInput'
 import { TokenSelectField } from 'src/components/input/TokenSelectField'
-import { TokenId, isStableToken } from 'src/config/tokens'
+import { TokenId, isStableToken, isUSDCVariant } from 'src/config/tokens'
 import { AccountBalances } from 'src/features/accounts/fetchBalances'
 import { useAppDispatch, useAppSelector } from 'src/features/store/hooks'
 import { SettingsMenu } from 'src/features/swap/SettingsMenu'
@@ -34,7 +34,7 @@ export function SwapFormCard() {
   return (
     <FloatingBox width="w-96" classes="overflow-visible">
       <div className="flex justify-between mb-5">
-        <h2 className="text-lg font-medium pl-1">Swap</h2>
+        <h2 className="pl-1 text-lg font-medium">Swap</h2>
         <SettingsMenu />
       </div>
       <SwapForm />
@@ -94,7 +94,7 @@ function SwapFormInputs({ balances }: FormInputProps) {
   const onChangeToken = (isFromToken: boolean) => (tokenId: string) => {
     const targetField = isFromToken ? 'fromTokenId' : 'toTokenId'
     const otherField = isFromToken ? 'toTokenId' : 'fromTokenId'
-    if (tokenId === TokenId.USDC) {
+    if (isUSDCVariant(tokenId)) {
       setFieldValue(targetField, tokenId)
       setFieldValue(otherField, TokenId.cUSD)
     } else if (isStableToken(tokenId)) {
@@ -109,7 +109,7 @@ function SwapFormInputs({ balances }: FormInputProps) {
 
   return (
     <div className="relative">
-      <div className="flex justify-between items-center py-2 px-3 mt-3 bg-greengray-lightest rounded-md">
+      <div className="flex items-center justify-between px-3 py-2 mt-3 rounded-md bg-greengray-lightest">
         <div className="flex items-center">
           <TokenSelectField name="fromTokenId" label="From Token" onChange={onChangeToken(true)} />
           <FieldDividerLine />
@@ -129,11 +129,11 @@ function SwapFormInputs({ balances }: FormInputProps) {
             type="number"
             step="any"
             placeholder="0.00"
-            className="w-36 pt-1 bg-transparent text-right text-xl font-mono focus:outline-none"
+            className="pt-1 font-mono text-xl text-right bg-transparent w-36 focus:outline-none"
           />
         </div>
       </div>
-      <div className="bg-white rounded-full absolute left-4 top-2/4 -translate-y-1/2 hover:rotate-180 transition-all">
+      <div className="absolute transition-all -translate-y-1/2 bg-white rounded-full left-4 top-2/4 hover:rotate-180">
         <ReverseTokenButton />
       </div>
       <div className="flex items-center justify-end my-2.5 px-1.5 text-xs text-gray-400">
@@ -143,15 +143,15 @@ function SwapFormInputs({ balances }: FormInputProps) {
           ? 'Loading...'
           : '...'}
       </div>
-      <div className="flex justify-between items-center py-2 px-3 mb-1 bg-greengray-lightest rounded-md">
+      <div className="flex items-center justify-between px-3 py-2 mb-1 rounded-md bg-greengray-lightest">
         <div className="flex items-center">
           <TokenSelectField name="toTokenId" label="To Token" onChange={onChangeToken(false)} />
           <FieldDividerLine />
         </div>
         {!isLoading ? (
-          <div className="text-xl text-right font-mono w-36 pt-2 overflow-hidden">{toAmount}</div>
+          <div className="pt-2 overflow-hidden font-mono text-xl text-right w-36">{toAmount}</div>
         ) : (
-          <div className="w-8 h-8 pt-1 flex items-center justify-center">
+          <div className="flex items-center justify-center w-8 h-8 pt-1">
             <div className="scale-[0.3] opacity-80">
               <Spinner />
             </div>
@@ -189,7 +189,7 @@ function FieldDividerLine() {
 
 function SlippageRow() {
   return (
-    <div className="flex items-center justify-center mt-5 space-x-7 text-sm" role="group">
+    <div className="flex items-center justify-center mt-5 text-sm space-x-7" role="group">
       <div>Max Slippage:</div>
       <RadioInput name="slippage" value="0.5" label="0.5%" />
       <RadioInput name="slippage" value="1.0" label="1.0%" />

--- a/src/images/tokens/TokenIcon.tsx
+++ b/src/images/tokens/TokenIcon.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image'
 import { memo } from 'react'
-import { Token, TokenId, isUSDCToken } from 'src/config/tokens'
+import { Token, TokenId, isUSDCVariant } from 'src/config/tokens'
 import CeloIcon from 'src/images/tokens/CELO.svg'
 import USDCIcon from 'src/images/tokens/USDC.svg'
 import cEURIcon from 'src/images/tokens/cEUR.svg'
@@ -32,7 +32,7 @@ function _TokenIcon({ token, size = 'm' }: Props) {
   else if (token?.id === TokenId.cUSD) imgSrc = cUSDIcon
   else if (token?.id === TokenId.cEUR) imgSrc = cEURIcon
   else if (token?.id === TokenId.cREAL) imgSrc = cREALIcon
-  else if (isUSDCToken(token?.id)) imgSrc = USDCIcon
+  else if (isUSDCVariant(token?.id)) imgSrc = USDCIcon
 
   if (imgSrc) {
     return (

--- a/src/images/tokens/TokenIcon.tsx
+++ b/src/images/tokens/TokenIcon.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image'
 import { memo } from 'react'
-import { Token, TokenId } from 'src/config/tokens'
+import { Token, TokenId, isUSDCToken } from 'src/config/tokens'
 import CeloIcon from 'src/images/tokens/CELO.svg'
 import USDCIcon from 'src/images/tokens/USDC.svg'
 import cEURIcon from 'src/images/tokens/cEUR.svg'
@@ -13,16 +13,28 @@ interface Props {
 }
 
 function _TokenIcon({ token, size = 'm' }: Props) {
+  const { actualSize, fontSize } = sizeValues[size]
+
+  if (!token) {
+    return (
+      <div
+        className="flex items-center justify-center bg-white border border-gray-200 rounded-full"
+        style={{
+          width: actualSize,
+          height: actualSize,
+        }}
+      ></div>
+    )
+  }
+
   let imgSrc
   if (token?.id === TokenId.CELO) imgSrc = CeloIcon
   else if (token?.id === TokenId.cUSD) imgSrc = cUSDIcon
   else if (token?.id === TokenId.cEUR) imgSrc = cEURIcon
   else if (token?.id === TokenId.cREAL) imgSrc = cREALIcon
-  else if (token?.id === TokenId.USDC) imgSrc = USDCIcon
+  else if (isUSDCToken(token?.id)) imgSrc = USDCIcon
 
-  const { actualSize, fontSize } = sizeValues[size]
-
-  if (token && imgSrc) {
+  if (imgSrc) {
     return (
       <Image
         src={imgSrc}
@@ -34,36 +46,24 @@ function _TokenIcon({ token, size = 'm' }: Props) {
     )
   }
 
-  if (token) {
-    return (
-      <div
-        className="flex items-center justify-center rounded-full"
-        style={{
-          width: actualSize,
-          height: actualSize,
-          backgroundColor: token.color || '#9CA4A9',
-        }}
-      >
-        <div
-          className="font-semibold text-white"
-          style={{
-            fontSize,
-          }}
-        >
-          {token.symbol[0].toUpperCase()}
-        </div>
-      </div>
-    )
-  }
-
   return (
     <div
-      className="flex items-center justify-center rounded-full bg-white border border-gray-200"
+      className="flex items-center justify-center rounded-full"
       style={{
         width: actualSize,
         height: actualSize,
+        backgroundColor: token.color || '#9CA4A9',
       }}
-    ></div>
+    >
+      <div
+        className="font-semibold text-white"
+        style={{
+          fontSize,
+        }}
+      >
+        {token.symbol[0].toUpperCase()}
+      </div>
+    </div>
   )
 }
 


### PR DESCRIPTION
### Description
This PR changes the token ID for the specific USDC variant currently supported on Celo main net (axlUSDC) and allows for the specification of additional USDC token variants. 

Additionally, I replaced checks for the USDC token with checks for USDC variants.

I also introduced checks to display the correct list of the available swap tokens based on the connected chain.

### Other changes
Made a change in the TokenIcon component to check for missing token before logic to get specific token icons

### Tested

axlUSDC is specified everywhere it was previously labelled USDC when connected to Celo main net

When connected to the test networks USDC label is displayed 

When axlUSDC is selected cUSD is automatically selected as the only swap option


### Related issues
Fixes #59 

### Backwards compatibility
N/A

### Documentation
N/A