### PR TITLE
fix: display rounded max balance, but swap true balance

### DIFF
--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -15,7 +15,7 @@ import { SwapDirection, SwapFormValues } from 'src/features/swap/types'
 import { useFormValidator } from 'src/features/swap/useFormValidator'
 import { useSwapQuote } from 'src/features/swap/useSwapQuote'
 import { FloatingBox } from 'src/layout/FloatingBox'
-import { fromWeiRounded } from 'src/utils/amount'
+import { fromWei, fromWeiRounded } from 'src/utils/amount'
 import { useAccount } from 'wagmi'
 
 const initialValues: SwapFormValues = {
@@ -91,7 +91,7 @@ function SwapFormInputs({ balances }: { balances: AccountBalances }) {
 
   const roundedBalance = fromWeiRounded(balances[fromTokenId], Tokens[fromTokenId].decimals)
   const onClickUseMax = () => {
-    setFieldValue('amount', roundedBalance)
+    setFieldValue('amount', fromWei(balances[fromTokenId]))
     if (fromTokenId === TokenId.CELO) {
       toast.warn('Consider keeping some CELO for transaction fees')
     }


### PR DESCRIPTION
### Description

This PR is to fix a rounding issue that would break swapping when using the 'use max functionality.' This fix displays the rounded value but swaps the users' max balance (or very close to it using an existing wei conversion function). Users should be able to swap their max balance now. 

### Other changes

N/A

### Tested

swapped max values for various tokens using a range of amounts 

### Related issues

- Fixes #89 

### Checklist before requesting a review

- [ x ] I have performed a self-review of my own code
