### PR TITLE
feat: add mu03 support

### DIFF
--- a/src/components/input/TokenSelectField.tsx
+++ b/src/components/input/TokenSelectField.tsx
@@ -1,15 +1,14 @@
 import { useField } from 'formik'
-import { useMemo } from 'react'
 import { ChevronIcon } from 'src/components/Chevron'
 import { Select } from 'src/components/input/Select'
-import { TokenId, getTokenById, getTokenOptionsByChainId } from 'src/config/tokens'
+import { TokenId, getTokenById } from 'src/config/tokens'
 import { TokenIcon } from 'src/images/tokens/TokenIcon'
-import { useNetwork } from 'wagmi'
 
 type Props = {
   name: string
   label: string
   onChange?: (optionValue: string) => void
+  tokenOptions: TokenId[]
 }
 
 const DEFAULT_VALUE = {
@@ -17,13 +16,8 @@ const DEFAULT_VALUE = {
   value: '',
 }
 
-export function TokenSelectField({ name, label, onChange }: Props) {
+export function TokenSelectField({ name, label, onChange, tokenOptions }: Props) {
   const [field, , helpers] = useField<string>(name)
-
-  const { chain } = useNetwork()
-  const tokenOptions = useMemo(() => {
-    return chain ? getTokenOptionsByChainId(chain.id) : Object.values(TokenId)
-  }, [chain])
 
   const handleChange = (optionValue: string) => {
     helpers.setValue(optionValue || '')

--- a/src/config/exchanges.ts
+++ b/src/config/exchanges.ts
@@ -40,8 +40,31 @@ export const AlfajoresExchanges: Exchange[] = [
       '0x87D61dA3d668797786D73BC674F053f87111570d',
     ],
   },
+  {
+    providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
+    id: '0x3e6d9109df536ba3f4c166e598bdfe132dca06573a54ca40c2b6f23ac6bd6cc6',
+    assets: [
+      '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
+      '0x87D61dA3d668797786D73BC674F053f87111570d',
+    ],
+  },
+  {
+    providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
+    id: '0xcfaa6be9334ee54fda94f2cfdf4c8bc376f24ce008ab9559b2a06b9fc388e78c',
+    assets: [
+      '0xE4D517785D091D3c54818832dB6094bcc2744545',
+      '0x87D61dA3d668797786D73BC674F053f87111570d',
+    ],
+  },
+  {
+    providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
+    id: '0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37',
+    assets: [
+      '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
+      '0x6e673502c5b55F3169657C004e5797fFE5be6653',
+    ],
+  },
 ]
-
 export const BaklavaExchanges: Exchange[] = [
   {
     providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
@@ -75,8 +98,31 @@ export const BaklavaExchanges: Exchange[] = [
       '0xD4079B322c392D6b196f90AA4c439fC2C16d6770',
     ],
   },
+  {
+    providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
+    id: '0x3e6d9109df536ba3f4c166e598bdfe132dca06573a54ca40c2b6f23ac6bd6cc6',
+    assets: [
+      '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
+      '0xD4079B322c392D6b196f90AA4c439fC2C16d6770',
+    ],
+  },
+  {
+    providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
+    id: '0xcfaa6be9334ee54fda94f2cfdf4c8bc376f24ce008ab9559b2a06b9fc388e78c',
+    assets: [
+      '0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1',
+      '0xD4079B322c392D6b196f90AA4c439fC2C16d6770',
+    ],
+  },
+  {
+    providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
+    id: '0xe807b1ebe8b57ac4e5c1b8d51fcf8e3b21e919fd788bab807886c4f446a74d37',
+    assets: [
+      '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
+      '0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B',
+    ],
+  },
 ]
-
 export const CeloExchanges: Exchange[] = [
   {
     providerAddr: '0x22d9db95E6Ae61c104A7B6F6C78D7993B94ec901',

--- a/src/config/tokens.ts
+++ b/src/config/tokens.ts
@@ -64,7 +64,6 @@ export const axlUSDC: Token = Object.freeze({
   decimals: 6,
 })
 
-
 export const axlEUROC: Token = Object.freeze({
   id: TokenId.axlEUROC,
   symbol: TokenId.axlEUROC,

--- a/src/config/tokens.ts
+++ b/src/config/tokens.ts
@@ -1,4 +1,5 @@
 import { ChainId } from 'src/config/chains'
+import { MentoExchanges } from 'src/config/exchanges'
 import { Color } from 'src/styles/Color'
 import { areAddressesEqual } from 'src/utils/addresses'
 
@@ -20,6 +21,8 @@ export enum TokenId {
   cEUR = 'cEUR',
   cREAL = 'cREAL',
   axlUSDC = 'axlUSDC',
+  axlEUROC = 'axlEUROC',
+  eXOF = 'eXOF',
 }
 
 export const NativeStableTokenIds = [TokenId.cUSD, TokenId.cEUR, TokenId.cREAL]
@@ -62,12 +65,31 @@ export const axlUSDC: Token = Object.freeze({
   decimals: 6,
 })
 
+// TODO: Doulbe check
+export const axlEUROC: Token = Object.freeze({
+  id: TokenId.axlEUROC, // TODO: Change to EUROC
+  symbol: TokenId.axlEUROC, // TODO: Change to EUROC
+  name: 'Axelar EUROC',
+  color: Color.usdcBlue, // TODO: Change to EUROC
+  decimals: 6,
+})
+
+export const eXOF: Token = Object.freeze({
+  id: TokenId.eXOF, // TODO: Change to eXOF
+  symbol: TokenId.eXOF, // TODO: Change to eXOF
+  name: 'West African Franc',
+  color: Color.usdcBlue, // TODO: Change to eXOF
+  decimals: 6, // TODO: Change to eXOF
+})
+
 export const Tokens: Record<TokenId, Token> = {
   CELO,
   cUSD,
   cEUR,
   cREAL,
   axlUSDC,
+  axlEUROC,
+  eXOF,
 }
 
 export const TokenAddresses: Record<ChainId, Record<TokenId, Address>> = Object.freeze({
@@ -77,6 +99,8 @@ export const TokenAddresses: Record<ChainId, Record<TokenId, Address>> = Object.
     [TokenId.cEUR]: '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
     [TokenId.cREAL]: '0xE4D517785D091D3c54818832dB6094bcc2744545',
     [TokenId.axlUSDC]: '0x87D61dA3d668797786D73BC674F053f87111570d',
+    [TokenId.axlEUROC]: '0x6e673502c5b55F3169657C004e5797fFE5be6653',
+    [TokenId.eXOF]: '',
   },
   [ChainId.Baklava]: {
     [TokenId.CELO]: '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
@@ -84,6 +108,8 @@ export const TokenAddresses: Record<ChainId, Record<TokenId, Address>> = Object.
     [TokenId.cEUR]: '0xf9ecE301247aD2CE21894941830A2470f4E774ca',
     [TokenId.cREAL]: '0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1',
     [TokenId.axlUSDC]: '0xD4079B322c392D6b196f90AA4c439fC2C16d6770',
+    [TokenId.axlEUROC]: '0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B',
+    [TokenId.eXOF]: '',
   },
   [ChainId.Celo]: {
     [TokenId.CELO]: '0x471EcE3750Da237f93B8E339c536989b8978a438',
@@ -91,6 +117,8 @@ export const TokenAddresses: Record<ChainId, Record<TokenId, Address>> = Object.
     [TokenId.cEUR]: '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
     [TokenId.cREAL]: '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787',
     [TokenId.axlUSDC]: '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
+    [TokenId.axlEUROC]: '',
+    [TokenId.eXOF]: '',
   },
 })
 
@@ -106,9 +134,34 @@ export function isNativeStableToken(tokenId: string) {
   return NativeStableTokenIds.includes(tokenId as TokenId)
 }
 
+export function isSwappable(token_1: string, token_2: string, chainId: ChainId) {
+  const exchanges = MentoExchanges[chainId]
+
+  if (!exchanges) return false
+
+  if (token_1 === token_2) return false
+
+  return exchanges.some(
+    (obj) =>
+      obj.assets.includes(getTokenAddress(token_1 as TokenId, chainId)) &&
+      obj.assets.includes(getTokenAddress(token_2 as TokenId, chainId))
+  )
+}
+
+export function getSwappableTokenOptions(token: string, chainId: ChainId) {
+  return getTokenOptionsByChainId(chainId)
+    .filter((tkn) => isSwappable(tkn, token, chainId))
+    .filter((tkn) => token !== tkn)
+}
+
 export function getTokenOptionsByChainId(chainId: ChainId): TokenId[] {
   const tokensForChain = TokenAddresses[chainId]
-  return tokensForChain ? (Object.keys(TokenAddresses[chainId]) as TokenId[]) : []
+
+  return tokensForChain
+    ? Object.entries(tokensForChain)
+        .filter(([, tokenAddress]) => tokenAddress !== '') // Allows incomplete 'TokenAddresses' list i.e When tokens are not on all chains
+        .map(([tokenId]) => tokenId as TokenId)
+    : []
 }
 
 export function getTokenById(id: string): Token | null {

--- a/src/config/tokens.ts
+++ b/src/config/tokens.ts
@@ -134,8 +134,8 @@ export function isNativeStableToken(tokenId: string) {
   return NativeStableTokenIds.includes(tokenId as TokenId)
 }
 
-export function isSwappable(token_1: string, token_2: string, chainId: ChainId) {
-  const exchanges = MentoExchanges[chainId]
+export function isSwappable(token_1: string, token_2: string, chainId: number) {
+  const exchanges = MentoExchanges[chainId as ChainId]
 
   if (!exchanges) return false
 

--- a/src/config/tokens.ts
+++ b/src/config/tokens.ts
@@ -22,7 +22,6 @@ export enum TokenId {
   cREAL = 'cREAL',
   axlUSDC = 'axlUSDC',
   axlEUROC = 'axlEUROC',
-  eXOF = 'eXOF',
 }
 
 export const NativeStableTokenIds = [TokenId.cUSD, TokenId.cEUR, TokenId.cREAL]
@@ -65,21 +64,13 @@ export const axlUSDC: Token = Object.freeze({
   decimals: 6,
 })
 
-// TODO: Doulbe check
+
 export const axlEUROC: Token = Object.freeze({
-  id: TokenId.axlEUROC, // TODO: Change to EUROC
-  symbol: TokenId.axlEUROC, // TODO: Change to EUROC
+  id: TokenId.axlEUROC,
+  symbol: TokenId.axlEUROC,
   name: 'Axelar EUROC',
   color: Color.usdcBlue, // TODO: Change to EUROC
   decimals: 6,
-})
-
-export const eXOF: Token = Object.freeze({
-  id: TokenId.eXOF, // TODO: Change to eXOF
-  symbol: TokenId.eXOF, // TODO: Change to eXOF
-  name: 'West African Franc',
-  color: Color.usdcBlue, // TODO: Change to eXOF
-  decimals: 6, // TODO: Change to eXOF
 })
 
 export const Tokens: Record<TokenId, Token> = {
@@ -89,7 +80,6 @@ export const Tokens: Record<TokenId, Token> = {
   cREAL,
   axlUSDC,
   axlEUROC,
-  eXOF,
 }
 
 export const TokenAddresses: Record<ChainId, Record<TokenId, Address>> = Object.freeze({
@@ -100,7 +90,6 @@ export const TokenAddresses: Record<ChainId, Record<TokenId, Address>> = Object.
     [TokenId.cREAL]: '0xE4D517785D091D3c54818832dB6094bcc2744545',
     [TokenId.axlUSDC]: '0x87D61dA3d668797786D73BC674F053f87111570d',
     [TokenId.axlEUROC]: '0x6e673502c5b55F3169657C004e5797fFE5be6653',
-    [TokenId.eXOF]: '',
   },
   [ChainId.Baklava]: {
     [TokenId.CELO]: '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
@@ -109,7 +98,6 @@ export const TokenAddresses: Record<ChainId, Record<TokenId, Address>> = Object.
     [TokenId.cREAL]: '0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1',
     [TokenId.axlUSDC]: '0xD4079B322c392D6b196f90AA4c439fC2C16d6770',
     [TokenId.axlEUROC]: '0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B',
-    [TokenId.eXOF]: '',
   },
   [ChainId.Celo]: {
     [TokenId.CELO]: '0x471EcE3750Da237f93B8E339c536989b8978a438',
@@ -118,7 +106,6 @@ export const TokenAddresses: Record<ChainId, Record<TokenId, Address>> = Object.
     [TokenId.cREAL]: '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787',
     [TokenId.axlUSDC]: '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
     [TokenId.axlEUROC]: '',
-    [TokenId.eXOF]: '',
   },
 })
 

--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -273,6 +273,7 @@ function SubmitButton() {
   const { switchNetworkAsync } = useSwitchNetwork()
   const { openConnectModal } = useConnectModal()
   const dispatch = useAppDispatch()
+  const { errors, touched } = useFormikContext<SwapFormValues>()
 
   const isAccountReady = address && isConnected
   const isOnCelo = chains.some((chn) => chn.id === chain?.id)
@@ -292,17 +293,20 @@ function SubmitButton() {
     }
   }
 
-  const { errors, touched } = useFormikContext<SwapFormValues>()
   const error =
     touched.amount && (errors.amount || errors.fromTokenId || errors.toTokenId || errors.slippage)
-  const text = error
-    ? error
-    : !isAccountReady
-    ? 'Connect Wallet'
-    : !isOnCelo
-    ? 'Switch to Celo Network'
-    : 'Continue'
+  let text;
 
+    if (error) {
+        text = error;
+    } else if (!isAccountReady) {
+        text = 'Connect Wallet';
+    } else if (!isOnCelo) {
+        text = 'Switch to Celo Network';
+    } else {
+        text = 'Continue';
+    }
+    
   const type = isAccountReady ? 'submit' : 'button'
   const onClick = isAccountReady ? (isOnCelo ? undefined : switchToNetwork) : openConnectModal
 

--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -6,7 +6,6 @@ import { Spinner } from 'src/components/animation/Spinner'
 import { Button3D } from 'src/components/buttons/3DButton'
 import { RadioInput } from 'src/components/input/RadioInput'
 import { TokenSelectField } from 'src/components/input/TokenSelectField'
-import { ChainId } from 'src/config/chains'
 import {
   TokenId,
   Tokens,
@@ -111,7 +110,7 @@ function SwapFormInputs({ balances }: { balances: AccountBalances }) {
   }, [quote, setFieldValue])
 
   useEffect(() => {
-    if ( chain && isConnected && !isSwappable(values.fromTokenId, values.toTokenId, chain?.id) ) {
+    if (chain && isConnected && !isSwappable(values.fromTokenId, values.toTokenId, chain?.id)) {
       setFieldValue(
         'toTokenId',
         swappableTokenOptions.length < 1 ? TokenId.cUSD : swappableTokenOptions[0]

--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -308,7 +308,13 @@ function SubmitButton() {
   }
 
   const type = isAccountReady ? 'submit' : 'button'
-  const onClick = isAccountReady ? (isOnCelo ? undefined : switchToNetwork) : openConnectModal
+  let onClick
+
+  if (!isAccountReady) {
+    onClick = openConnectModal
+  } else if (!isOnCelo) {
+    onClick = switchToNetwork
+  }
 
   const showLongError = typeof error === 'string' && error?.length > 50
 

--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -6,6 +6,7 @@ import { Spinner } from 'src/components/animation/Spinner'
 import { Button3D } from 'src/components/buttons/3DButton'
 import { RadioInput } from 'src/components/input/RadioInput'
 import { TokenSelectField } from 'src/components/input/TokenSelectField'
+import { ChainId } from 'src/config/chains'
 import {
   TokenId,
   Tokens,
@@ -110,7 +111,7 @@ function SwapFormInputs({ balances }: { balances: AccountBalances }) {
   }, [quote, setFieldValue])
 
   useEffect(() => {
-    if (!isSwappable(values.fromTokenId, values.toTokenId, chain?.id) && isConnected) {
+    if ( chain && isConnected && !isSwappable(values.fromTokenId, values.toTokenId, chain?.id) ) {
       setFieldValue(
         'toTokenId',
         swappableTokenOptions.length < 1 ? TokenId.cUSD : swappableTokenOptions[0]

--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -295,18 +295,18 @@ function SubmitButton() {
 
   const error =
     touched.amount && (errors.amount || errors.fromTokenId || errors.toTokenId || errors.slippage)
-  let text;
+  let text
 
-    if (error) {
-        text = error;
-    } else if (!isAccountReady) {
-        text = 'Connect Wallet';
-    } else if (!isOnCelo) {
-        text = 'Switch to Celo Network';
-    } else {
-        text = 'Continue';
-    }
-    
+  if (error) {
+    text = error
+  } else if (!isAccountReady) {
+    text = 'Connect Wallet'
+  } else if (!isOnCelo) {
+    text = 'Switch to Celo Network'
+  } else {
+    text = 'Continue'
+  }
+
   const type = isAccountReady ? 'submit' : 'button'
   const onClick = isAccountReady ? (isOnCelo ? undefined : switchToNetwork) : openConnectModal
 

--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -276,7 +276,7 @@ function SubmitButton() {
   const dispatch = useAppDispatch()
 
   const isAccountReady = address && isConnected
-  const isOnCelo = chains.some((chn) => chn.id === chain.id)
+  const isOnCelo = chains.some((chn) => chn.id === chain?.id)
 
   const switchToNetwork = async () => {
     try {


### PR DESCRIPTION
### Description

This PR adds support for MU03 changes, it also lays the groundwork to make future stable additions more scaleable. The main changes are: 

- axlEUROC has been added
- The exchanges have been updated based on the config produced by the Mento SDK. 
- The token selection validation logic updated to a more scalable solution. Instead of relying on a case-by-case custom validation, the new approach is based on the exchange configuration to check if pairs are swappable. This will ensure greater flexibility and scalability for future changes.


The deployed preview for this branch can be viewed [here](https://mento-8ijde4480-mentolabs.vercel.app/?vercelToolbarCode=msZTvGphOvMZTxJ)

### Other changes

Token outputs are now limited to valid options, only showing users valid options. When a token is selected only the list of token which are valid to swap are shown instead of showing invalid options and programatically changing their selections. 

I noticed unwanted behaviour when connected to a non Celo network, so I added non Celo network detection as part of logic which handles enabling and disabling of swap button. 

### Tested

I performed the regression tests to confirm core functionality still works
I also selected selected each token as input to ensured only swappable outputs were displayed

### Related issues

- Fixes #98 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] The PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [x] I have run the [regression tests](https://www.notion.so/Mento-Web-App-Regression-Tests-37bd43a7da8d4e38b65993320a33d557)
