### PR TITLE
fix: unwanted swap redirect

### DIFF
--- a/src/features/swap/types.ts
+++ b/src/features/swap/types.ts
@@ -9,6 +9,7 @@ export interface SwapFormValues {
   quote: number | string
   direction: SwapDirection
   slippage: string
+  submitType: string
 }
 
 export type ToCeloRates = Partial<Record<TokenId, ExchangeRate>>


### PR DESCRIPTION
### Description

Fixes:
- unwanted redirect to swap confirmation page when reversing tokens

👁️ noticed an issue when reversing tokens sometimes it takes time to fetch balances and shows 'Amount exceeds balance' so [added an issue](https://github.com/mento-protocol/mento-web/issues/101) to target that behaviour 

### Other changes

previous form submission logic in `SwapForm.tsx` in `SubmitButton()` function that was causing `checkTradingLimits()` call in `useFormValidator.tsx` to fail sometimes.

### Tested

manually

### Related issues

- Fixes #91 

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] The PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] I have run the [regression tests](https://www.notion.so/Mento-Web-App-Regression-Tests-37bd43a7da8d4e38b65993320a33d557)
