### PR TITLE
feat:exof support on baklava

### DIFF
--- a/src/config/exchanges.ts
+++ b/src/config/exchanges.ts
@@ -122,6 +122,22 @@ export const BaklavaExchanges: Exchange[] = [
       '0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B',
     ],
   },
+  {
+    providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
+    id: '0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07',
+    assets: [
+      '0x64c1D812673E93Bc036AdC3D547d9950696DA5Af',
+      '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
+    ],
+  },
+  {
+    providerAddr: '0xFF9a3da00F42839CD6D33AD7adf50bCc97B41411',
+    id: '0x66c5917862c8dc589e789d43752aa17ad251126276ce88ea20d89865e67bdabe',
+    assets: [
+      '0x64c1D812673E93Bc036AdC3D547d9950696DA5Af',
+      '0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B',
+    ],
+  },
 ]
 export const CeloExchanges: Exchange[] = [
   {

--- a/src/config/tokens.ts
+++ b/src/config/tokens.ts
@@ -22,6 +22,7 @@ export enum TokenId {
   cREAL = 'cREAL',
   axlUSDC = 'axlUSDC',
   axlEUROC = 'axlEUROC',
+  eXOF = 'eXOF',
 }
 
 export const NativeStableTokenIds = [TokenId.cUSD, TokenId.cEUR, TokenId.cREAL]
@@ -71,6 +72,13 @@ export const axlEUROC: Token = Object.freeze({
   color: Color.usdcBlue, // TODO: Change to EUROC
   decimals: 6,
 })
+export const eXOF: Token = Object.freeze({
+  id: TokenId.eXOF,
+  symbol: TokenId.eXOF,
+  name: 'eXOF',
+  color: Color.usdcBlue, // TODO: Change to EUROC
+  decimals: 6,
+})
 
 export const Tokens: Record<TokenId, Token> = {
   CELO,
@@ -79,6 +87,7 @@ export const Tokens: Record<TokenId, Token> = {
   cREAL,
   axlUSDC,
   axlEUROC,
+  eXOF,
 }
 
 export const TokenAddresses: Record<ChainId, Record<TokenId, Address>> = Object.freeze({
@@ -89,6 +98,7 @@ export const TokenAddresses: Record<ChainId, Record<TokenId, Address>> = Object.
     [TokenId.cREAL]: '0xE4D517785D091D3c54818832dB6094bcc2744545',
     [TokenId.axlUSDC]: '0x87D61dA3d668797786D73BC674F053f87111570d',
     [TokenId.axlEUROC]: '0x6e673502c5b55F3169657C004e5797fFE5be6653',
+    [TokenId.eXOF]: '',
   },
   [ChainId.Baklava]: {
     [TokenId.CELO]: '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',
@@ -97,6 +107,7 @@ export const TokenAddresses: Record<ChainId, Record<TokenId, Address>> = Object.
     [TokenId.cREAL]: '0x6a0EEf2bed4C30Dc2CB42fe6c5f01F80f7EF16d1',
     [TokenId.axlUSDC]: '0xD4079B322c392D6b196f90AA4c439fC2C16d6770',
     [TokenId.axlEUROC]: '0x6f90ac394b1F45290d3023e4Ba0203005cAF2A4B',
+    [TokenId.eXOF]: '0x64c1D812673E93Bc036AdC3D547d9950696DA5Af',
   },
   [ChainId.Celo]: {
     [TokenId.CELO]: '0x471EcE3750Da237f93B8E339c536989b8978a438',
@@ -105,6 +116,7 @@ export const TokenAddresses: Record<ChainId, Record<TokenId, Address>> = Object.
     [TokenId.cREAL]: '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787',
     [TokenId.axlUSDC]: '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
     [TokenId.axlEUROC]: '0x061cc5a2C863E0C1Cb404006D559dB18A34C762d',
+    [TokenId.eXOF]: '',
   },
 })
 

--- a/src/config/tokens.ts
+++ b/src/config/tokens.ts
@@ -77,7 +77,7 @@ export const eXOF: Token = Object.freeze({
   symbol: TokenId.eXOF,
   name: 'eXOF',
   color: Color.usdcBlue, // TODO: Change to EUROC
-  decimals: 6,
+  decimals: 18,
 })
 
 export const Tokens: Record<TokenId, Token> = {

--- a/src/features/swap/SwapConfirm.tsx
+++ b/src/features/swap/SwapConfirm.tsx
@@ -111,7 +111,10 @@ export function SwapConfirmCard({ formValues }: Props) {
       return
     }
     const rateBN = new BigNumber(rate)
-    if (rateBN.lt(MIN_EXCHANGE_RATE) || rateBN.gt(MAX_EXCHANGE_RATE)) {
+    if (
+      ((toTokenId || fromTokenId) !== 'eXOF' && rateBN.lt(MIN_EXCHANGE_RATE)) ||
+      rateBN.gt(MAX_EXCHANGE_RATE)
+    ) {
       toast.error('Rate seems incorrect')
       return
     }

--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -234,17 +234,21 @@ function AmountField({
 }
 
 function ReverseTokenButton() {
-  const { values, setFieldValue } = useFormikContext<SwapFormValues>()
+  const { values, setValues } = useFormikContext<SwapFormValues>()
   const { fromTokenId, toTokenId } = values
 
-  const onClickReverse = () => {
-    setFieldValue('fromTokenId', toTokenId)
-    setFieldValue('toTokenId', fromTokenId)
+  const onClickReverse = async () => {
+    setValues({
+      ...values,
+      toTokenId: fromTokenId,
+      fromTokenId: toTokenId,
+    })
   }
 
   return (
     <button
       title="Swap inputs"
+      type="button"
       onClick={onClickReverse}
       className="flex items-center justify-center rounded-full border h-[36px] w-[36px] border-primary-dark dark:border-none  dark:bg-[#545457] text-primary-dark dark:text-white"
     >


### PR DESCRIPTION
### Description

This PR adds eXOF support for baklava to allow testing using the UI. 

There's also a fix for error causing the reverse token button to trigger a swap confirm step, by adding 'button' type as it defaults to 'submit'. 

### Other changes

I've set the rate range check to ignore eXOF swaps until we decide if we need them. (If we do the range can be configured on a per pair basis)

I've also set the form values in a single function call in the reverse button as setting them sequentially caused weird quote fetching behaviour. 

### Tested

I didn't do all the regression test cases, but I did a good few swaps with different currencies and amounts. I did notice there is still rounding issue sometimes when using max, so I've created a issue to capture this, otherwise the quotes and  swaps work as expected. 

### Related issues

- Fixes #91 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] The PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] I have run the [regression tests](https://www.notion.so/Mento-Web-App-Regression-Tests-37bd43a7da8d4e38b65993320a33d557)
