### PR TITLE
fix: default to mainnet token options when not connected

### DIFF
--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -6,6 +6,7 @@ import { Spinner } from 'src/components/animation/Spinner'
 import { Button3D } from 'src/components/buttons/3DButton'
 import { RadioInput } from 'src/components/input/RadioInput'
 import { TokenSelectField } from 'src/components/input/TokenSelectField'
+import { Celo } from 'src/config/chains'
 import {
   TokenId,
   Tokens,
@@ -92,13 +93,13 @@ function SwapFormInputs({ balances }: { balances: AccountBalances }) {
   const { chain } = useNetwork()
 
   const tokensForChain = useMemo(() => {
-    return chain ? getTokenOptionsByChainId(chain?.id) : Object.values(TokenId)
+    return chain ? getTokenOptionsByChainId(chain?.id) : getTokenOptionsByChainId(Celo.chainId)
   }, [chain])
 
   const { values, setFieldValue } = useFormikContext<SwapFormValues>()
 
   const swappableTokenOptions = useMemo(() => {
-    return chain ? getSwappableTokenOptions(values.fromTokenId, chain?.id) : Object.values(TokenId)
+    return getSwappableTokenOptions(values.fromTokenId, chain ? chain?.id : Celo.chainId)
   }, [chain, values])
 
   const { amount, direction, fromTokenId, toTokenId } = values


### PR DESCRIPTION
### Description

This PR makes changes to the token list logic to get the main net token list when no wallet is connected

### Other changes

N/A

### Tested

Checked the token list in the preview version of these changes

### Related issues

- Fixes #issue number here

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] The PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] I have run the [regression tests](https://www.notion.so/Mento-Web-App-Regression-Tests-37bd43a7da8d4e38b65993320a33d557)
