### PR TITLE
feat: add eXOF on alfajores

### DIFF
--- a/src/config/exchanges.ts
+++ b/src/config/exchanges.ts
@@ -64,6 +64,22 @@ export const AlfajoresExchanges: Exchange[] = [
       '0x6e673502c5b55F3169657C004e5797fFE5be6653',
     ],
   },
+  {
+    providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
+    id: '0x269dcbdbc07fff1a4aaab9c7c03b3f629cd9bbed49aa0efebab874e4da1ffd07',
+    assets: [
+      '0xB0FA15e002516d0301884059c0aaC0F0C72b019D',
+      '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
+    ],
+  },
+  {
+    providerAddr: '0x9B64E8EaBD1a035b148cE970d3319c5C3Ad53EC3',
+    id: '0x66c5917862c8dc589e789d43752aa17ad251126276ce88ea20d89865e67bdabe',
+    assets: [
+      '0xB0FA15e002516d0301884059c0aaC0F0C72b019D',
+      '0x6e673502c5b55F3169657C004e5797fFE5be6653',
+    ],
+  },
 ]
 export const BaklavaExchanges: Exchange[] = [
   {

--- a/src/config/tokens.ts
+++ b/src/config/tokens.ts
@@ -98,7 +98,7 @@ export const TokenAddresses: Record<ChainId, Record<TokenId, Address>> = Object.
     [TokenId.cREAL]: '0xE4D517785D091D3c54818832dB6094bcc2744545',
     [TokenId.axlUSDC]: '0x87D61dA3d668797786D73BC674F053f87111570d',
     [TokenId.axlEUROC]: '0x6e673502c5b55F3169657C004e5797fFE5be6653',
-    [TokenId.eXOF]: '',
+    [TokenId.eXOF]: '0xB0FA15e002516d0301884059c0aaC0F0C72b019D',
   },
   [ChainId.Baklava]: {
     [TokenId.CELO]: '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8',


### PR DESCRIPTION
### Description

We just ran the eXOF CGP on Alfajores so it can now be added to the frontend. 

### Tested

Got some Wagmi errors so couldn't run it locally, but I guess this is small enough that it should work?

### Related issues

- Fixes https://github.com/mento-protocol/mento-web/issues/71

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] The PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] I have run the [regression tests](https://www.notion.so/Mento-Web-App-Regression-Tests-37bd43a7da8d4e38b65993320a33d557)
