### PR TITLE
fix: footer had same z-index as <main> and was covering the token dropdown on small screens

### DIFF
--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -25,7 +25,7 @@ export function AppLayout({ pathName, children }: PropsWithChildren<Props>) {
       >
         <TopBlur />
         <Header />
-        <main className={`relative z-20 flex items-center justify-center grow`}>{children}</main>
+        <main className={`relative z-30 flex items-center justify-center grow`}>{children}</main>
         <Footer />
         <BottomGrid />
       </div>


### PR DESCRIPTION
1. Check Markus' video on discord for reproduction https://discord.com/channels/966739027782955068/1065941733260660777/1255081871612575744
1. Reproduce on app.mento.org by making your browser window small enough for the footer to overlap with the token dropdown of the "To:" dropdown
1. See that you can't click the elements that overlap with the footer
1. Check this branch's environment URL and see that the problem is fixed
