### PR TITLE
fix: pass token decimals to fromWei

### DIFF
--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -122,7 +122,7 @@ function SwapFormInputs({ balances }: { balances: AccountBalances }) {
   const roundedBalance = fromWeiRounded(balances[fromTokenId], Tokens[fromTokenId].decimals)
   const isRoundedBalanceGreaterThanZero = Boolean(Number.parseInt(roundedBalance) > 0)
   const onClickUseMax = () => {
-    setFieldValue('amount', fromWei(balances[fromTokenId]))
+    setFieldValue('amount', fromWei(balances[fromTokenId], Tokens[fromTokenId].decimals))
     if (fromTokenId === TokenId.CELO) {
       toast.warn('Consider keeping some CELO for transaction fees')
     }


### PR DESCRIPTION
### Description

When Use Max is clicked, it was adding a wrong value to the amount field for tokens with decimals != 18
This PR fixes the issue by passing the correct decimal amount fetched from token config to onClickUseMax


### Tested

Tested on local and preview

### Related issues

- Fixes https://discord.com/channels/966739027782955068/981497164817637447/1261276291638755348

