### PR TITLE
refactor: revert z index change + add y-spacing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mento-protocol/mento-web",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A simple DApp for Celo Mento exchanges",
   "keywords": [
     "Celo",

--- a/src/components/nav/Footer.tsx
+++ b/src/components/nav/Footer.tsx
@@ -16,7 +16,7 @@ import { isStale } from 'src/utils/time'
 
 export function Footer() {
   return (
-    <div className="z-20 inline-flex justify-between w-full p-3 sm:px-5 sm:py-7">
+    <div className="z-20 inline-flex justify-between w-full p-3 mt-10 sm:px-5 sm:py-7 pt-7">
       <div className="inline-flex items-start justify-start gap-4">
         <div className="p-2 justify-start items-start gap-2.5 flex">
           <FooterIconLink to={links.twitter} imgSrc={Twitter} alt="Twitter" />

--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -25,7 +25,7 @@ export function AppLayout({ pathName, children }: PropsWithChildren<Props>) {
       >
         <TopBlur />
         <Header />
-        <main className={`relative z-30 flex items-center justify-center grow`}>{children}</main>
+        <main className={`relative z-20 flex items-center justify-center grow`}>{children}</main>
         <Footer />
         <BottomGrid />
       </div>


### PR DESCRIPTION
### Description

In a recent change we modified the z index of the main card component. This had an impact on the connect wallet modal meaning the user options such as changing network and disconnect button could not be selected as the modal was now behind the main component. 

This reverts the z index change, then adds some spacing to the footer to enable tokens in the to list to be selectable on short phones.

### Other changes

- None

### Tested

- Tested in responsive browser

### Related issues

- Fixes https://github.com/mento-protocol/mento-web/issues/137

### Checklist before requesting a review

- [ x] I have performed a self-review of my own code
- [ x] The PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] I have run the [regression tests](https://www.notion.so/Mento-Web-App-Regression-Tests-37bd43a7da8d4e38b65993320a33d557)
