### PR TITLE
fix: ensure 'Use Max' button visibility for token balances > 0

### DIFF
--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -125,7 +125,7 @@ function SwapFormInputs({ balances }: { balances: AccountBalances }) {
   }, [setFieldValue, chain, values, swappableTokenOptions, isConnected])
 
   const roundedBalance = fromWeiRounded(balances[fromTokenId], Tokens[fromTokenId].decimals)
-  const isRoundedBalanceGreaterThanZero = Boolean(Number.parseInt(roundedBalance) > 0)
+  const isRoundedBalanceGreaterThanZero = Boolean(Number.parseFloat(roundedBalance) > 0)
   const onClickUseMax = () => {
     const maxAmount = fromWei(balances[fromTokenId], Tokens[fromTokenId].decimals)
     setFieldValue('amount', maxAmount)


### PR DESCRIPTION
### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

This PR addresses an issue where the _Use Max_ button was not displayed for tokens with balances less than 1. The root cause was the use of Number.parseInt() to evaluate token balances, which truncates fractional values, resulting in balances like 0.7 being treated as 0.

**Problem:**

- The Use Max button was visible only when the token balance was greater than or equal to 1.

- Tokens with fractional balances (e.g., 0.5, 0.7) incorrectly failed the check.

- This prevented users from using the _Use Max_ functionality for tokens with balances below 1, potentially impacting usability for large-token-value ecosystems.

**Solution:**

- Replaced Number.parseInt() with Number.parseFloat() to account for fractional token balances.

**Impact:**

- Improves user experience by enabling _Use Max_ functionality for all tokens with balances above 0, regardless of whether the balance is fractional.

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

- Tested manually by allocating multiple tokens with fractional and above one amount.

### Related issues

- Fixes #issue number here

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] The PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] I have run the [regression tests](https://www.notion.so/Mento-Web-App-Regression-Tests-37bd43a7da8d4e38b65993320a33d557)
