### PR TITLE
fix: use max rounding issue

### DIFF
--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -25,7 +25,7 @@ import { SwapDirection, SwapFormValues } from 'src/features/swap/types'
 import { useFormValidator } from 'src/features/swap/useFormValidator'
 import { useSwapQuote } from 'src/features/swap/useSwapQuote'
 import { FloatingBox } from 'src/layout/FloatingBox'
-import { fromWeiAsString, fromWeiRounded, toSignificant } from 'src/utils/amount'
+import { fromWei, fromWeiRounded, toSignificant } from 'src/utils/amount'
 import { logger } from 'src/utils/logger'
 import { escapeRegExp, inputRegex } from 'src/utils/string'
 import { useAccount, useNetwork, useSwitchNetwork } from 'wagmi'
@@ -127,7 +127,7 @@ function SwapFormInputs({ balances }: { balances: AccountBalances }) {
   const roundedBalance = fromWeiRounded(balances[fromTokenId], Tokens[fromTokenId].decimals)
   const isRoundedBalanceGreaterThanZero = Boolean(Number.parseInt(roundedBalance) > 0)
   const onClickUseMax = () => {
-    const maxAmount = fromWeiAsString(balances[fromTokenId], Tokens[fromTokenId].decimals)
+    const maxAmount = fromWei(balances[fromTokenId], Tokens[fromTokenId].decimals)
     setFieldValue('amount', maxAmount)
 
     setFieldValue('direction', 'in')

--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -25,7 +25,7 @@ import { SwapDirection, SwapFormValues } from 'src/features/swap/types'
 import { useFormValidator } from 'src/features/swap/useFormValidator'
 import { useSwapQuote } from 'src/features/swap/useSwapQuote'
 import { FloatingBox } from 'src/layout/FloatingBox'
-import { fromWei, fromWeiRounded, toSignificant } from 'src/utils/amount'
+import { fromWeiAsString, fromWeiRounded, toSignificant } from 'src/utils/amount'
 import { logger } from 'src/utils/logger'
 import { escapeRegExp, inputRegex } from 'src/utils/string'
 import { useAccount, useNetwork, useSwitchNetwork } from 'wagmi'
@@ -127,7 +127,7 @@ function SwapFormInputs({ balances }: { balances: AccountBalances }) {
   const roundedBalance = fromWeiRounded(balances[fromTokenId], Tokens[fromTokenId].decimals)
   const isRoundedBalanceGreaterThanZero = Boolean(Number.parseInt(roundedBalance) > 0)
   const onClickUseMax = () => {
-    const maxAmount = fromWei(balances[fromTokenId], Tokens[fromTokenId].decimals)
+    const maxAmount = fromWeiAsString(balances[fromTokenId], Tokens[fromTokenId].decimals)
     setFieldValue('amount', maxAmount)
 
     setFieldValue('direction', 'in')
@@ -332,7 +332,7 @@ function SubmitButton() {
   const showLongError = typeof error === 'string' && error?.length > 50
 
   return (
-    <div className="flex flex-col w-full items-center justify-center">
+    <div className="flex flex-col items-center justify-center w-full">
       {showLongError ? (
         <div className="bg-[#E14F4F] rounded-md text-white p-4 mb-6">{error}</div>
       ) : null}

--- a/src/features/swap/useSwapQuote.ts
+++ b/src/features/swap/useSwapQuote.ts
@@ -48,7 +48,7 @@ export function useSwapQuote(
         quoteWei = (await mento.getAmountIn(fromTokenAddr, toTokenAddr, amountWeiBN)).toString()
       }
 
-      const quote = fromWei(quoteWei, quoteDecimals).toString()
+      const quote = fromWei(quoteWei, quoteDecimals)
       const rateIn = calcExchangeRate(amountWei, amountDecimals, quoteWei, quoteDecimals)
       const rate = isSwapIn ? rateIn : invertExchangeRate(rateIn)
 

--- a/src/utils/amount.ts
+++ b/src/utils/amount.ts
@@ -18,6 +18,16 @@ export function fromWei(
   return parseFloat(formatUnits(flooredValue, decimals))
 }
 
+export function fromWeiAsString(
+  value: NumberT | null | undefined,
+  decimals = STANDARD_TOKEN_DECIMALS
+): string {
+  if (!value) return '0'
+  const valueString = value.toString().trim()
+  const flooredValue = new BigNumber(valueString).toFixed(0, BigNumber.ROUND_FLOOR)
+  return formatUnits(flooredValue, decimals)
+}
+
 // Similar to fromWei above but rounds to set number of decimals
 // with a minimum floor, configured per token
 export function fromWeiRounded(

--- a/src/utils/amount.ts
+++ b/src/utils/amount.ts
@@ -11,16 +11,6 @@ export type NumberT = BigNumber.Value
 export function fromWei(
   value: NumberT | null | undefined,
   decimals = STANDARD_TOKEN_DECIMALS
-): number {
-  if (!value) return 0
-  const valueString = value.toString().trim()
-  const flooredValue = new BigNumber(valueString).toFixed(0, BigNumber.ROUND_FLOOR)
-  return parseFloat(formatUnits(flooredValue, decimals))
-}
-
-export function fromWeiAsString(
-  value: NumberT | null | undefined,
-  decimals = STANDARD_TOKEN_DECIMALS
 ): string {
   if (!value) return '0'
   const valueString = value.toString().trim()


### PR DESCRIPTION
### Description

One of the utility functions [fromWei()](https://github.com/mento-protocol/mento-web/blob/a391ba4bdd06e4fdf86517d63144590583db2fab/src/utils/amount.ts#L11) was added to convert a value from Wei to a more human-readable format by returning a number. 

The implementation led to precision loss due to the limitations of JavaScript's number type, which can only represent numbers with up to 15-17 significant decimal digits. This was problematic for us as most ERC20 tokens have 18. This caused problems for users if they had a balance like **1122656452787798154** which would have been rounded up in the app resulting in a balance like **1.1226564527877982** which is actually larger than their balance. This would cause their swap to fail if they used the **use max** button instead of just typing an amount.

**Fix** 
The function was modified to keep the formatted value as a string instead of converting to a JS number. This preserves the precision and avoids any rounding errors. 

### Other changes

- The function was also used in [useSwapQuote](https://github.com/mento-protocol/mento-web/blob/a391ba4bdd06e4fdf86517d63144590583db2fab/src/features/swap/useSwapQuote.ts#L51), which has also been updated

### Tested

- Executed swaps to verify they work 
- Verified useMax now works for amounts that previously were being rounded up

### Related issues

- Fixes #107 

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] The PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] I have run the [regression tests](https://www.notion.so/Mento-Web-App-Regression-Tests-37bd43a7da8d4e38b65993320a33d557)
