### PR TITLE
Fix: Prevented transforming to incorrect amount with >=22 digits

### DIFF
--- a/src/utils/amount.ts
+++ b/src/utils/amount.ts
@@ -44,7 +44,7 @@ export function toWei(
   decimals = STANDARD_TOKEN_DECIMALS
 ): BigNumber {
   if (!value) return new BigNumber(0)
-  const valueString = value.toString().trim()
+  const valueString = new BigNumber(value).toFixed().trim()
   const components = valueString.split('.')
   if (components.length === 1) {
     return new BigNumber(parseUnits(valueString, decimals).toString())


### PR DESCRIPTION
### Description
Currently, it transforms an amount with >=22 digits to an incorrect amount and proceeds to the confirmation state (e.g., 7478773923223123234925 -> 7.479). The scope is to make it the correct amount with >=22 digits.

### Other changes
None

### Tested
Put 7478773923223123234925 amount and tried to proceed to confirmation when it exceeded balance

### Related issues

- Fixes #157 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] The PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] I have run the [regression tests](https://www.notion.so/Mento-Web-App-Regression-Tests-37bd43a7da8d4e38b65993320a33d557)
