### PR TITLE
fix: remove amounts nearly equal check

### DIFF
--- a/src/features/swap/useFormValidator.ts
+++ b/src/features/swap/useFormValidator.ts
@@ -5,7 +5,7 @@ import { Tokens, getTokenAddress, getTokenByAddress } from 'src/config/tokens'
 import { AccountBalances } from 'src/features/accounts/fetchBalances'
 import { getMentoSdk } from 'src/features/sdk'
 import { SwapFormValues } from 'src/features/swap/types'
-import { areAmountsNearlyEqual, parseAmount, toWei } from 'src/utils/amount'
+import { parseAmount, toWei } from 'src/utils/amount'
 import { logger } from 'src/utils/logger'
 import { useChainId } from 'wagmi'
 
@@ -23,7 +23,7 @@ export function useFormValidator(balances: AccountBalances, lastUpdated: number 
         const tokenId = values.fromTokenId
         const tokenBalance = balances[tokenId]
         const weiAmount = toWei(parsedAmount, Tokens[values.fromTokenId].decimals)
-        if (weiAmount.gt(tokenBalance) && !areAmountsNearlyEqual(weiAmount, tokenBalance)) {
+        if (weiAmount.gt(tokenBalance)) {
           return { amount: 'Amount exceeds balance' }
         }
         const { exceeds, errorMsg } = await checkTradingLimits(values, chainId)


### PR DESCRIPTION
### Description

the issue discovered by @Andrew718PLTS  https://app.zenhub.com/workspaces/sprint-6458911097b7ec002c15f0d6/issues/gh/mento-protocol/mento-web/183
was caused by a bad nearly equal check on the balance that assumed tokens have 18 decimals. That is also why this issue only happened for USDC etc. and not for cUSD.

Since the balance should be strictly gt than the amount I removed the additional condition. 
