### PR TITLE
fix: form validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mento-protocol/mento-web",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "description": "A simple DApp for Celo Mento exchanges",
   "keywords": [
     "Celo",

--- a/src/config/tokens.ts
+++ b/src/config/tokens.ts
@@ -203,10 +203,20 @@ export async function isSwappable(token_1: string, token_2: string, chainId: num
   )
 }
 
-export function getSwappableTokenOptions(token: string, chainId: ChainId) {
-  return getTokenOptionsByChainId(chainId)
-    .filter((tkn) => isSwappable(tkn, token, chainId))
-    .filter((tkn) => token !== tkn)
+export async function getSwappableTokenOptions(token: string, chainId: ChainId) {
+  const options = getTokenOptionsByChainId(chainId)
+
+  const swappableOptions = await Promise.all(
+    options.map(async (tkn) => ({
+      token: tkn,
+      isSwappable: await isSwappable(tkn, token, chainId),
+    }))
+  ).then((results) => {
+    return results
+      .filter((result) => result.isSwappable && result.token !== token)
+      .map((result) => result.token)
+  })
+  return swappableOptions
 }
 
 export function getTokenOptionsByChainId(chainId: ChainId): TokenId[] {


### PR DESCRIPTION
### Description

The form validation was broken because we called the async function `isSwappable` in the filter function without waiting for the promises to be resolved.
This fix ensure only valid token combinations can be selected 

### Other changes



### Tested

Ensured both multihop and direct broker swaps work, verified only valid pairs can be selected.


### Related issues



### Checklist before requesting a review

