### PR TITLE
fix: made footer icons clickable again

### DIFF
--- a/src/components/nav/BottomGrid.tsx
+++ b/src/components/nav/BottomGrid.tsx
@@ -4,7 +4,7 @@ import BackgroundTiles from 'src/images/background/background_tiles_light.png'
 
 export function BottomGrid() {
   return (
-    <div className="absolute bottom-0 z-10 transform -translate-x-1/2 left-1/2">
+    <div className="absolute bottom-0 transform -translate-x-1/2 left-1/2 pointer-events-none">
       <div className="w-screen h-[201px] relative">
         <Image
           src={BackgroundTiles}


### PR DESCRIPTION
footer icons were covered by the bottom grid graphic

simplest solution I found was to simply make the bottom-grid pass through all clicks to the below elements effectively making it invisible to the mouse/trackpad but still visible visually 