### PR TITLE
Fix: Updated mento-sdk with fix to use cache to getTradablePairForTokens to remove delay on navigation to Confirm Swap state

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@celo/rainbowkit-celo": "^0.11.0",
     "@headlessui-float/react": "^0.11.2",
     "@headlessui/react": "^1.7.13",
-    "@mento-protocol/mento-sdk": "^1.0.3",
+    "@mento-protocol/mento-sdk": "^1.0.4",
     "@metamask/jazzicon": "https://github.com/jmrossy/jazzicon#7a8df28",
     "@metamask/post-message-stream": "6.1.2",
     "@metamask/providers": "10.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1892,15 +1892,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mento-protocol/mento-sdk@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "@mento-protocol/mento-sdk@npm:1.0.3"
+"@mento-protocol/mento-sdk@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "@mento-protocol/mento-sdk@npm:1.0.4"
   dependencies:
     "@mento-protocol/mento-core-ts": "npm:^0.2.0"
     mento-router-ts: "npm:^0.2.0"
   peerDependencies:
     ethers: ^5.7
-  checksum: 10/b0910cef6c6d76d124e0ca442c35d987bd3d8092ab6c6bcc3f34c7b81615e9ca73745d17409b429817afa59a7ebb655771b57c71c6797aec3862c3e333049840
+  checksum: 10/4c22132f0fd44123bd68ae74e5b3d5fe90d8d592d7ab2d0960172925771f8d76b21185325d10478a7522d09c0333a587cfb4f66348d94d9386bff2de5732e54e
   languageName: node
   linkType: hard
 
@@ -1911,7 +1911,7 @@ __metadata:
     "@celo/rainbowkit-celo": "npm:^0.11.0"
     "@headlessui-float/react": "npm:^0.11.2"
     "@headlessui/react": "npm:^1.7.13"
-    "@mento-protocol/mento-sdk": "npm:^1.0.3"
+    "@mento-protocol/mento-sdk": "npm:^1.0.4"
     "@metamask/jazzicon": "https://github.com/jmrossy/jazzicon#7a8df28"
     "@metamask/post-message-stream": "npm:6.1.2"
     "@metamask/providers": "npm:10.2.1"


### PR DESCRIPTION
### Description

There's a delay after pressing the 'Continue' button, that was because of missing using the cache on getting tradable pairs by mento-sdk method. This PR is to update the mento-sdk to a version that contains a fix.

### Other changes
None

### Tested
1. Navigate to the app
2. Enter a valid amount to any input
3. Click the 'Continue' button

### Related issues

- Fixes #issue number here

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] The PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] I have run the [regression tests](https://www.notion.so/Mento-Web-App-Regression-Tests-37bd43a7da8d4e38b65993320a33d557)
