### PR TITLE
Feat: Added locator for confirm swap button

### DIFF
--- a/src/components/buttons/3DButton.tsx
+++ b/src/components/buttons/3DButton.tsx
@@ -8,6 +8,7 @@ type BaseButtonProps = {
   isDisabled?: boolean
   isWalletConnected?: boolean
   isBalanceLoaded?: boolean
+  dataTestId?: string
 }
 
 export enum Button3DText {
@@ -15,6 +16,7 @@ export enum Button3DText {
   continue = 'Continue',
   balanceStillLoading = 'Balance still loading...',
   switchToCeloNetwork = 'Switch to Celo Network',
+  preparingSwap = 'Preparing Swap...',
 }
 
 export const Button3D = ({
@@ -26,6 +28,7 @@ export const Button3D = ({
   isDisabled,
   isWalletConnected,
   isBalanceLoaded,
+  dataTestId,
 }: PropsWithChildren<BaseButtonProps>) => {
   return (
     <button
@@ -33,6 +36,7 @@ export const Button3D = ({
       onClick={onClick}
       type={type}
       disabled={isDisabled}
+      data-testId={dataTestId}
     >
       <span
         className={`group font-inter outline-offset-4 cursor-pointer ${getShadowButtonColor({

--- a/src/features/swap/SwapConfirm.tsx
+++ b/src/features/swap/SwapConfirm.tsx
@@ -246,7 +246,12 @@ export function SwapConfirmCard({ formValues }: Props) {
       </div>
 
       <div className="flex w-full px-6 pb-6 mt-6">
-        <Button3D isFullWidth onClick={onSubmit} isDisabled={isButtonDisabled}>
+        <Button3D
+          isFullWidth
+          onClick={onSubmit}
+          isDisabled={isButtonDisabled}
+          dataTestId={'confirm-button'}
+        >
           {buttonText}
         </Button3D>
       </div>

--- a/src/features/swap/components/SubmitButton.tsx
+++ b/src/features/swap/components/SubmitButton.tsx
@@ -84,7 +84,7 @@ export function SubmitButton({ isWalletConnected, isBalanceLoaded }: ISubmitButt
     if (!isOnCelo) return Button3DText.switchToCeloNetwork
     if (isWalletConnected && !isBalanceLoaded) return Button3DText.balanceStillLoading
     if (hasError) return errorText
-    if (isSubmitting) return 'Preparing Swap...'
+    if (isSubmitting) return Button3DText.preparingSwap
     return Button3DText.continue
   }, [errorText, hasError, isWalletConnected, isOnCelo, isBalanceLoaded, isSubmitting])
 


### PR DESCRIPTION
### Description

After the refactor the swap button has different states with the specified text. Therefore, we can't take this button by particular text anymore, and I added a unique locator.

### Other changes
Made a new enum value for a button text.

### Tested
Run any swap autotest or check the locator on the Confirm Swap state for the main button.

### Related issues

- Fixes #issue number here

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] The PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] I have run the [regression tests](https://www.notion.so/Mento-Web-App-Regression-Tests-37bd43a7da8d4e38b65993320a33d557)
