### PR TITLE
Fix: Updated pr-check ci job to prevent unused 'test' job

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -94,7 +94,7 @@ jobs:
       - name: lint 
         run: yarn run lint
 
-  unit-tests:
+  test:
     runs-on: ubuntu-latest
     needs: [build]
     steps:


### PR DESCRIPTION
### Description

There was a `test` job that was remaining even after the `unit-tests` job is completed (it's been renamed to `unit-tests` in previous PR). Here I just renamed it back to `test`.

### Other changes

None

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #issue number here

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have added unit-tests that prove my fix is effective or that my feature works
- [ ] The PR title follows the [conventions](https://www.notion.so/Git-Branching-and-Commit-Message-Conventions-18f66f7d06444cfcbac5725ffbc7c04a?pvs=4#9355048863c549ef92fe210a8a1298aa)
- [ ] I have run the [regression tests](https://www.notion.so/Mento-Web-App-Regression-Tests-37bd43a7da8d4e38b65993320a33d557)
- [ ] The Smoke Test Run is passed ([how to check the Smoke Test Run job result](https://www.notion.so/mentolabs/How-to-analyze-the-Smoke-Test-Run-1b6a2148cc5c80ec8834f2dd97491680))
