### PR TITLE
fix: parallelize balance queries

### DIFF
--- a/src/features/accounts/fetchBalances.ts
+++ b/src/features/accounts/fetchBalances.ts
@@ -41,10 +41,13 @@ async function _fetchBalances(address: string, chainId: number): Promise<Record<
     return { tokenSymbol, balance }
   })
 
-  const results = await Promise.all(balancePromises)
-  results.forEach(({ tokenSymbol, balance }) => {
-    if (balance !== undefined) {
-      tokenBalances[tokenSymbol] = balance
+  const results = await Promise.allSettled(balancePromises)
+  results.forEach((result) => {
+    if (result.status === 'fulfilled') {
+      const { tokenSymbol, balance } = result.value
+      if (balance !== undefined) {
+        tokenBalances[tokenSymbol] = balance
+      }
     }
   })
 

--- a/src/features/accounts/fetchBalances.ts
+++ b/src/features/accounts/fetchBalances.ts
@@ -35,9 +35,19 @@ export const fetchBalances = createAsyncThunk<
 async function _fetchBalances(address: string, chainId: number): Promise<Record<TokenId, string>> {
   validateAddress(address, 'fetchBalances')
   const tokenBalances: Partial<Record<TokenId, string>> = {}
-  for (const tokenSymbol of getTokenOptionsByChainId(chainId)) {
-    tokenBalances[tokenSymbol] = await getTokenBalance({ address, chainId, tokenSymbol })
-  }
+
+  const balancePromises = getTokenOptionsByChainId(chainId).map(async (tokenSymbol) => {
+    const balance = await getTokenBalance({ address, chainId, tokenSymbol })
+    return { tokenSymbol, balance }
+  })
+
+  const results = await Promise.all(balancePromises)
+  results.forEach(({ tokenSymbol, balance }) => {
+    if (balance !== undefined) {
+      tokenBalances[tokenSymbol] = balance
+    }
+  })
+
   return tokenBalances as Record<TokenId, string>
 }
 


### PR DESCRIPTION
### Description

Not sure why this was not done before, but this parallelizes the balance calls by using Promise.all, reducing the initial loading time from 5+ seconds to ~1s.

### Other changes

N/A

### Tested

Tested it locally to confirm the balances are loaded as expected
