### PR TITLE
Added explicit oracle error

### DIFF
--- a/src/features/swap/hooks/useSwapQuote.ts
+++ b/src/features/swap/hooks/useSwapQuote.ts
@@ -96,6 +96,7 @@ function getToastErrorMessage(
     case swapErrorMessage.includes(`can't create fixidity number larger than`):
       return 'Amount out is too large'
     case swapErrorMessage.includes(`no valid median`):
+      return `Oracle error. Price information for ${fromTokenSymbol} to ${toTokenSymbol} trades is currently unreliable.`
     case swapErrorMessage.includes(`Trading is suspended for this reference rate`):
       return (
         'Trading temporarily paused.  ' +


### PR DESCRIPTION
Previously, we were showing the same error message for two different cases:

1. The trading mode being > 0 for a feed (due to a breaker triggering or a trading limit hitting)
2. An oracle problem (no valid median due to outdated reports or not enough reporters)

I've added a more explicit error message for the second case now.